### PR TITLE
protect /posts

### DIFF
--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -9,19 +9,21 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { Post as PostEntity } from '@prisma/client';
 import { PostsService } from './posts.service';
 import { Logger } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/jwt.guard';
+import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('posts')
 export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   async create(
     @Req() req: any,
     @Body() createPostDto: CreatePostDto,
@@ -41,7 +43,8 @@ export class PostsController {
   }
 
   @Put(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   async update(
     @Req() req: any,
     @Param('id') id: string,
@@ -51,7 +54,8 @@ export class PostsController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   async remove(@Req() req: any, @Param('id') id: string): Promise<PostEntity> {
     return await this.postsService.remove(req.user.userId, +id);
   }


### PR DESCRIPTION
This pull request includes several changes to the `PostsController` in the `src/posts/posts.controller.ts` file to enhance authentication and authorization. The most important changes involve switching from `AuthGuard` to `JwtAuthGuard` and adding `ApiBearerAuth` for improved security and API documentation.

Authentication and Authorization Enhancements:

* Replaced `AuthGuard('jwt')` with `JwtAuthGuard` for the `create`, `update`, and `remove` methods to use a more specific JWT-based guard. [[1]](diffhunk://#diff-a5704d25abd8488955a915a6bcde49b3244e8e465e67299ff908cf726b2879b9L12-R26) [[2]](diffhunk://#diff-a5704d25abd8488955a915a6bcde49b3244e8e465e67299ff908cf726b2879b9L44-R47) [[3]](diffhunk://#diff-a5704d25abd8488955a915a6bcde49b3244e8e465e67299ff908cf726b2879b9L54-R58)
* Added `@ApiBearerAuth('JWT-auth')` decorator to the `create`, `update`, and `remove` methods to include JWT authentication in the API documentation. [[1]](diffhunk://#diff-a5704d25abd8488955a915a6bcde49b3244e8e465e67299ff908cf726b2879b9L12-R26) [[2]](diffhunk://#diff-a5704d25abd8488955a915a6bcde49b3244e8e465e67299ff908cf726b2879b9L44-R47) [[3]](diffhunk://#diff-a5704d25abd8488955a915a6bcde49b3244e8e465e67299ff908cf726b2879b9L54-R58)