### PR TITLE
enable schema introspection

### DIFF
--- a/src/graphql/graphql.module.ts
+++ b/src/graphql/graphql.module.ts
@@ -2,11 +2,15 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { join } from 'node:path';
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default';
 
 @Module({
   imports: [
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
+      playground: false,
+      introspection: true,
+      plugins: [ApolloServerPluginLandingPageLocalDefault()],
       typePaths: ['./**/*.graphql'],
       definitions: {
         path: join(process.cwd(), 'src/graphql.ts'),


### PR DESCRIPTION
This pull request includes updates to the GraphQL module configuration in `src/graphql/graphql.module.ts` to enhance the development experience and improve security.

Key changes:

* Added import for `ApolloServerPluginLandingPageLocalDefault` to enable the local landing page plugin for Apollo Server.
* Disabled the GraphQL playground by setting `playground` to `false`.
* Enabled introspection by setting `introspection` to `true`.
* Added the `ApolloServerPluginLandingPageLocalDefault` plugin to the Apollo Server configuration.