### PR TITLE
date time scalar type

### DIFF
--- a/src/posts/posts.graphql
+++ b/src/posts/posts.graphql
@@ -1,9 +1,14 @@
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type Post {
   id: ID!
   userId: ID!
   content: String!
-  createdAt: String
-  updatedAt: String
+  createdAt: DateTime
+  updatedAt: DateTime
 }
 
 input CreatePostInput {

--- a/src/users/users.graphql
+++ b/src/users/users.graphql
@@ -1,3 +1,8 @@
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type User {
   id: ID!
   email: String!
@@ -5,8 +10,8 @@ type User {
   password: String!
   avatar: String
   posts:     [Post]  
-  createdAt: String
-  updatedAt: String
+  createdAt: DateTime
+  updatedAt: DateTime
 }
 
 input CreateUserInput {


### PR DESCRIPTION
This pull request includes changes to the GraphQL schema for both posts and users to improve date-time handling by introducing a new `DateTime` scalar type.

Schema improvements:

* [`src/posts/posts.graphql`](diffhunk://#diff-50bb876e5e705b5263c6269b8092d34bbe604b2a0b1c50b1cb9b1ba50ad9e014R1-R11): Added a new `DateTime` scalar type and updated the `createdAt` and `updatedAt` fields in the `Post` type to use this new scalar.
* [`src/users/users.graphql`](diffhunk://#diff-e98383a9859dc275f54ba38a27b7917186d709c7351ffa682465bafe540ea325R1-R14): Added a new `DateTime` scalar type and updated the `createdAt` and `updatedAt` fields in the `User` type to use this new scalar.