### PR TITLE
delete user method

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -1099,6 +1099,9 @@ type Mutation {
   deletePost(id: Int!): Post!
   deleteRsvp(id: Int!): RSVP!
 
+  """Deletes a user by ID"""
+  deleteUser(id: Int!): User!
+
   """for creating a new user"""
   register(createUserInput: CreateUserInput!): User!
   removeLike(id: Int!): Like!

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -67,7 +67,7 @@ export class UsersResolver {
   /**
    * Deletes a user by ID.
    * @param {number} id - The ID of the user to delete.
-   * @returns {Promise<User>} - The deleted user object.
+   * @returns {Promise<UserResponse>} - The deleted user object.
    */
   @Mutation(() => User, {
     name: 'deleteUser',

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -63,4 +63,30 @@ export class UsersResolver {
     });
     return user;
   }
+
+  /**
+   * Deletes a user by ID.
+   * @param {number} id - The ID of the user to delete.
+   * @returns {Promise<User>} - The deleted user object.
+   */
+  @Mutation(() => User, {
+    name: 'deleteUser',
+    description: 'Deletes a user by ID',
+  })
+  async deleteUser(
+    @Args('id', { type: () => Int }) id: number,
+  ): Promise<UserResponse> {
+    this.logger.logDebug(`removing user ...`, {
+      metadata: {
+        id,
+      },
+    });
+    const user = await this.usersService.deleteUser(id);
+    this.logger.info(`user removed successfully`, {
+      metadata: {
+        user,
+      },
+    });
+    return user;
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -225,4 +225,34 @@ export class UsersService {
       });
     }
   }
+
+  /**
+   * Deletes a user by their ID.
+   * @param {number} id - The ID of the user to delete.
+   * @return {Promise<UserResponse>} - The deleted user object.
+   * @throws {NotFoundException} - If the user is not found.
+   */
+  async deleteUser(id: number): Promise<UserResponse> {
+    try {
+      const user = await this.prismaService.user.delete({
+        where: { id },
+        omit: {
+          password: true,
+        },
+        include: DEFAULT_USER_INCLUDES,
+      });
+
+      if (!user) {
+        throw new NotFoundException(`User with ID ${id} not found.`);
+      }
+
+      return user;
+    } catch (error) {
+      this.handler.handleError(error, {
+        operation: 'deleteUser',
+        service: 'UsersService',
+        metadata: { id },
+      });
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces functionality to delete a user by their ID. The changes span across the GraphQL schema, resolver, and service layers. Below are the most important changes:

GraphQL Schema Update:
* Added `deleteUser` mutation to the `Mutation` type in `src/schema.gql` to allow deleting a user by ID.

Resolver Implementation:
* Added `deleteUser` method in `UsersResolver` class to handle the `deleteUser` mutation, including logging and returning the deleted user object.

Service Method:
* Added `deleteUser` method in `UsersService` class to perform the actual deletion of the user from the database, handle errors, and return the deleted user object.