### PR TITLE
refresh tokens feature

### DIFF
--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -8,6 +8,8 @@ import { UserResponse } from 'src/users/users.types';
 import { ErrorHandler } from 'src/error-handler/error.util';
 import { AuthResponse } from './types/auth.types';
 import { LoginInput } from './types/login.input';
+import { RefreshToken } from './decorators/refresh-token.decorator';
+
 /**
  * Resolver for handling authentication-related operations.
  * @class AuthResolver
@@ -75,6 +77,35 @@ export class AuthResolver {
     });
     return {
       message: 'Login successful',
+      tokens,
+    };
+  }
+
+  /**
+   * refreshes the access token using the refresh token.
+   * @param {string} refreshToken - The refresh token used to obtain a new access token.
+   * @returns {Promise<AuthResponse>} - The authentication response containing the new token pair and message.
+   */
+  @Mutation(() => AuthResponse, {
+    name: 'refreshTokens',
+    description: 'for refreshing access token and refresh token',
+  })
+  async refreshTokens(
+    @RefreshToken() refreshToken: string,
+  ): Promise<AuthResponse> {
+    this.logger.logDebug(`refreshing tokens ...`, {
+      metadata: {
+        refreshToken,
+      },
+    });
+    const tokens = await this.authService.refreshTokens(refreshToken);
+    this.logger.info(`token refreshed successfully`, {
+      metadata: {
+        tokens,
+      },
+    });
+    return {
+      message: 'Tokens refreshed successfully',
       tokens,
     };
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import { UserWithoutPassword } from 'src/users/users.types';
 import { UsersService } from 'src/users/users.service';
 import * as argon from 'argon2';
 import { LoginInput } from './types/login.input';
+import { ErrorHandler } from 'src/error-handler/error.util';
 
 @Injectable()
 export class AuthService {
@@ -13,6 +14,7 @@ export class AuthService {
   constructor(
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
+    private readonly handler: ErrorHandler,
   ) {}
 
   /**
@@ -39,7 +41,7 @@ export class AuthService {
   /**
    * generates JWT tokens
    * @param {UserWithoutPassword} user
-   * @returns {Promise<Tokens>}
+   * @returns {Promise<TokenPair>}
    */
   async generateTokens(user: UserWithoutPassword): Promise<TokenPair> {
     const payload: JwtPayload = {
@@ -56,5 +58,33 @@ export class AuthService {
       secret: process.env.JWT_REFRESH_SECRET || 'defaultRefreshSecret',
     });
     return { accessToken, refreshToken };
+  }
+
+  /**
+   * refreshes the JWT tokens
+   * @param {string} refreshToken
+   * @returns {Promise<TokenPair>}
+   * @throws {UnauthorizedException} if the refresh token is invalid
+   */
+  async refreshTokens(refreshToken: string): Promise<TokenPair> {
+    try {
+      const payload = await this.jwtService.verifyAsync(refreshToken, {
+        secret: process.env.JWT_REFRESH_SECRET || 'defaultRefreshSecret',
+      });
+      if (!payload) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+      const user = await this.usersService.findUserById(payload.sub);
+      if (!user) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+      return this.generateTokens(user);
+    } catch (error) {
+      this.handler.handleError(error, {
+        operation: 'refreshTokens',
+        service: 'AuthService',
+        metadata: { refreshToken },
+      });
+    }
   }
 }

--- a/src/auth/decorators/refresh-token.decorator.ts
+++ b/src/auth/decorators/refresh-token.decorator.ts
@@ -1,0 +1,12 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+export const RefreshToken = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const gqlContext = GqlExecutionContext.create(ctx);
+    const request = gqlContext.getContext().req;
+
+    // Extract refresh token from headers
+    return request.headers['x-refresh-token'] || null;
+  },
+);

--- a/src/auth/guards/refresh.guard.ts
+++ b/src/auth/guards/refresh.guard.ts
@@ -1,0 +1,19 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { AuthGuard } from '@nestjs/passport';
+import { Logger } from '@nestjs/common';
+
+@Injectable()
+export class RefreshTokenAuthGuard extends AuthGuard('jwt-refresh') {
+  private readonly logger = new Logger(RefreshTokenAuthGuard.name);
+
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    const request = ctx.getContext().req;
+
+    // Log headers for debugging
+    this.logger.debug(`Received headers: ${JSON.stringify(request.headers)}`);
+
+    return request;
+  }
+}

--- a/src/auth/strategies/refresh.strategy.ts
+++ b/src/auth/strategies/refresh.strategy.ts
@@ -2,9 +2,14 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-jwt';
 import { Request } from 'express';
-import { JwtPayload } from 'src/interfaces/auth.types';
+import { AuthenticatedUser, JwtPayload } from 'src/auth/types/auth.types';
 import { JwtService } from '@nestjs/jwt';
 
+/**
+ * Strategy for validating refresh tokens.
+ * This strategy extracts the refresh token from the request headers
+ * and verifies it using the JWT service.
+ */
 @Injectable()
 export class RefreshTokenStrategy extends PassportStrategy(
   Strategy,
@@ -31,12 +36,15 @@ export class RefreshTokenStrategy extends PassportStrategy(
         return refreshToken;
       },
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'JWT_SECRET',
+      secretOrKey: process.env.JWT_REFRESH_SECRET || 'defaultRefreshSecret',
       passReqToCallback: true,
     });
   }
 
-  async validate(req: Request, payload: JwtPayload) {
+  async validate(
+    req: Request,
+    payload: JwtPayload,
+  ): Promise<AuthenticatedUser> {
     this.logger.debug(`Starting validation for user ${payload.sub}`);
 
     const token = req.headers['x-refresh-token'];
@@ -64,7 +72,7 @@ export class RefreshTokenStrategy extends PassportStrategy(
       return {
         userId: decoded.sub,
         email: decoded.email,
-        refreshToken,
+        role: decoded.role,
       };
     } catch (error) {
       this.logger.error('Token verification failed:', error.message);

--- a/src/auth/types/auth.types.ts
+++ b/src/auth/types/auth.types.ts
@@ -1,0 +1,67 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { Role } from 'src/@generated';
+
+/**
+ * types used for authentication
+ */
+@ObjectType()
+export class TokenPair {
+  @Field(() => String, {
+    nullable: false,
+  })
+  accessToken: string;
+
+  @Field(() => String, {
+    nullable: false,
+  })
+  refreshToken: string;
+}
+
+@ObjectType()
+export class JwtPayload {
+  @Field(() => String, {
+    nullable: false,
+  })
+  email: string;
+
+  @Field(() => ID, {
+    nullable: false,
+  })
+  sub: number;
+
+  @Field(() => Role, {
+    nullable: false,
+  })
+  role: `${Role}`;
+}
+
+@ObjectType()
+export class AuthenticatedUser {
+  @Field(() => ID, {
+    nullable: false,
+  })
+  userId: number;
+
+  @Field(() => String, {
+    nullable: false,
+  })
+  email: string;
+
+  @Field(() => Role, {
+    nullable: false,
+  })
+  role: `${Role}`;
+}
+
+@ObjectType()
+export class AuthResponse {
+  @Field(() => String, {
+    nullable: false,
+  })
+  message: string;
+
+  @Field(() => TokenPair, {
+    nullable: false,
+  })
+  tokens: TokenPair;
+}

--- a/src/auth/types/login.input.ts
+++ b/src/auth/types/login.input.ts
@@ -1,0 +1,16 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsEmail } from 'class-validator';
+
+@InputType()
+export class LoginInput {
+  @IsEmail()
+  @Field(() => String, {
+    nullable: false,
+  })
+  email: string;
+
+  @Field(() => String, {
+    nullable: false,
+  })
+  password: string;
+}

--- a/src/error-handler/error.util.ts
+++ b/src/error-handler/error.util.ts
@@ -5,10 +5,15 @@ import {
   InternalServerErrorException,
   NotFoundException,
   ServiceUnavailableException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import {
+  JsonWebTokenError,
+  TokenExpiredError,
+  NotBeforeError,
+} from 'jsonwebtoken';
 import { AppLogger } from '../app.logger';
-import { HttpStatus } from '@nestjs/common';
 
 type ErrorContext = {
   operation?: string;
@@ -53,6 +58,7 @@ export class ErrorHandler {
       },
     );
 
+    // Handle Prisma Errors
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       this.handlePrismaError(error, context);
     }
@@ -61,17 +67,33 @@ export class ErrorHandler {
       throw new BadRequestException('Database validation failed');
     }
 
+    // ✅ Handle JWT Errors
+    if (error instanceof JsonWebTokenError) {
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    if (error instanceof TokenExpiredError) {
+      throw new UnauthorizedException('Token has expired');
+    }
+
+    if (error instanceof NotBeforeError) {
+      throw new UnauthorizedException('Token is not yet valid');
+    }
+
+    // Handle NestJS Exceptions
     if (
       error instanceof ConflictException ||
       error instanceof NotFoundException ||
       error instanceof BadRequestException ||
       error instanceof ForbiddenException ||
       error instanceof ServiceUnavailableException ||
-      error instanceof InternalServerErrorException
+      error instanceof InternalServerErrorException ||
+      error instanceof UnauthorizedException
     ) {
       throw error;
     }
 
+    // Default Internal Server Error
     throw new InternalServerErrorException(
       defaultMessage || 'An unexpected error occurred',
       {

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -2,6 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type AuthResponse {
+  message: String!
+  tokens: TokenPair!
+}
+
 input BoolFilter {
   equals: Boolean
   not: NestedBoolFilter
@@ -1085,6 +1090,11 @@ input LikeWhereUniqueInput {
   userId_postId_eventId: LikeUserIdPostIdEventIdCompoundUniqueInput
 }
 
+input LoginInput {
+  email: String!
+  password: String!
+}
+
 type Mutation {
   createCategory(createCategoryInput: CreateCategoryInput!): Category!
   createComment(createCommentInput: CreateCommentInput!): Comment!
@@ -1101,6 +1111,12 @@ type Mutation {
 
   """Deletes a user by ID"""
   deleteUser(id: Int!): User!
+
+  """for logging in a user"""
+  login(loginInput: LoginInput!): AuthResponse!
+
+  """for refreshing access token and refresh token"""
+  refreshTokens: AuthResponse!
 
   """for creating a new user"""
   register(createUserInput: CreateUserInput!): User!
@@ -1580,6 +1596,9 @@ type Query {
   eventRsvps(eventId: Int!): [RSVP!]!
   events: [Event!]!
 
+  """Finds all users"""
+  findAllUsers: [User!]!
+
   """Finds a user by ID"""
   findOneUser(id: Int!): User!
   like(id: Int!): Like!
@@ -1775,6 +1794,11 @@ input StringNullableFilter {
   not: NestedStringNullableFilter
   notIn: [String!]
   startsWith: String
+}
+
+type TokenPair {
+  accessToken: String!
+  refreshToken: String!
 }
 
 input UpdateCategoryInput {


### PR DESCRIPTION
This pull request introduces several enhancements to the authentication module, particularly focusing on implementing refresh token functionality. The most important changes include adding a new method for refreshing tokens, creating a decorator and guard for handling refresh tokens, updating the `AuthService` to support token refreshing, and expanding the error handling capabilities.

### Enhancements to Authentication Module:

* [`src/auth/auth.resolver.ts`](diffhunk://#diff-e8436fe0c02167317648bb2381e0a642364fac391bf43c1a98c099f8013cce25R83-R111): Added a new mutation `refreshTokens` for refreshing access tokens using a refresh token.
* [`src/auth/decorators/refresh-token.decorator.ts`](diffhunk://#diff-d22a1000ac45877ba0a8a600b96d15b830fa21c964e94901862c7d4ced29b6adR1-R12): Created a decorator `RefreshToken` to extract the refresh token from request headers.
* [`src/auth/guards/refresh.guard.ts`](diffhunk://#diff-33ca60381025d47a6da9428ad8a93a016ede0bd0e650e98c4d2590dde2b4bef1R1-R19): Implemented `RefreshTokenAuthGuard` to handle the validation of refresh tokens.
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR62-R89): Added a method `refreshTokens` to the `AuthService` class for generating new token pairs using a refresh token.

### Error Handling Improvements:

* [`src/error-handler/error.util.ts`](diffhunk://#diff-ab3cf521656ac9b548685fc72dcf667bc601cc7c83f2e9c1bf65332e0b5a9225R70-R96): Enhanced the `ErrorHandler` class to handle JWT errors such as `JsonWebTokenError`, `TokenExpiredError`, and `NotBeforeError`.

### GraphQL Schema Updates:

* [`src/schema.gql`](diffhunk://#diff-3f5956631dd838a368e31ce9f2e709a7c1344db549ceb4fb7f9f34699228ee6aR5-R9): Updated the schema to include new types and mutations related to authentication, such as `AuthResponse`, `TokenPair`, `LoginInput`, and the `refreshTokens` mutation. [[1]](diffhunk://#diff-3f5956631dd838a368e31ce9f2e709a7c1344db549ceb4fb7f9f34699228ee6aR5-R9) [[2]](diffhunk://#diff-3f5956631dd838a368e31ce9f2e709a7c1344db549ceb4fb7f9f34699228ee6aR1115-R1120) [[3]](diffhunk://#diff-3f5956631dd838a368e31ce9f2e709a7c1344db549ceb4fb7f9f34699228ee6aR1799-R1803)