### PR TITLE
recurrence service

### DIFF
--- a/src/recurrence/recurrence.module.ts
+++ b/src/recurrence/recurrence.module.ts
@@ -2,6 +2,6 @@ import { Module } from '@nestjs/common';
 import { RecurrenceService } from './recurrence.service';
 
 @Module({
-  providers: [RecurrenceService]
+  providers: [RecurrenceService],
 })
 export class RecurrenceModule {}

--- a/src/recurrence/recurrence.service.ts
+++ b/src/recurrence/recurrence.service.ts
@@ -90,12 +90,12 @@ export class RecurrenceService {
     try {
       const ruleSet = RRuleSet.parse(ruleSetString.trim());
       const dates = ruleSet.all();
-      const processedDates = this.processDates(dates, !!asString);
+      const processedDates: T extends true ? string[] : DateTime[] = this.processDates(dates, !!asString) as T extends true ? string[] : DateTime[];
 
       return {
         ruleSetString,
         ruleSet,
-        occurrences: processedDates as any,
+        occurrences: processedDates,
       };
     } catch (error: any) {
       throw new BadRequestException(

--- a/src/recurrence/recurrence.service.ts
+++ b/src/recurrence/recurrence.service.ts
@@ -1,4 +1,113 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  RRule,
+  RRuleSet,
+  DateTime,
+  type RRuleLike,
+  type RRuleSetLike,
+} from 'rrule-rust';
+
+export type StrictRRuleSetLike = Partial<RRuleSetLike> & {
+  tzid: string;
+  dtstart: DateTime;
+};
+
+export interface IRuleFeatOccurrences<T extends boolean = false> {
+  ruleSetString: string;
+  ruleSet?: RRuleSet;
+  occurrences: T extends true ? string[] : DateTime[];
+}
 
 @Injectable()
-export class RecurrenceService {}
+export class RecurrenceService {
+  createDateTime(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    second: number,
+  ): DateTime {
+    return DateTime.create(year, month, day, hour, minute, second, false);
+  }
+
+  getOccurrences<T extends boolean = false>(options: {
+    rruleOptions?: Partial<RRuleLike>;
+    rruleSetOptions?: StrictRRuleSetLike;
+    fromString?: string;
+    asString?: T;
+  }): IRuleFeatOccurrences<T> {
+    const { fromString, asString, rruleOptions, rruleSetOptions } = options;
+
+    if (fromString) {
+      return this.occurrencesFromString(fromString, asString);
+    }
+
+    if (!rruleOptions || !rruleSetOptions) {
+      throw new BadRequestException('Missing RRule or RRuleSet options.');
+    }
+
+    try {
+      const ruleSet = this.buildRuleSet(rruleOptions, rruleSetOptions);
+      const dates = ruleSet.all();
+      const processedDates = this.processDates(dates, !!asString);
+
+      return {
+        ruleSetString: ruleSet.toString(),
+        ruleSet,
+        occurrences: processedDates as any,
+      };
+    } catch (error: any) {
+      throw new InternalServerErrorException(
+        error?.message || 'Failed to build recurrence rule set.',
+      );
+    }
+  }
+
+  private buildRuleSet(
+    rruleOptions: Partial<RRuleLike>,
+    rruleSetOptions: StrictRRuleSetLike,
+  ): RRuleSet {
+    const rrule = new RRule(rruleOptions as RRuleLike);
+    return new RRuleSet({
+      ...rruleSetOptions,
+      rrules: [rrule],
+    });
+  }
+
+  private occurrencesFromString<T extends boolean = false>(
+    ruleSetString: string,
+    asString?: T,
+  ): IRuleFeatOccurrences<T> {
+    if (!ruleSetString?.trim()) {
+      throw new BadRequestException('Empty rule set string.');
+    }
+
+    try {
+      const ruleSet = RRuleSet.parse(ruleSetString.trim());
+      const dates = ruleSet.all();
+      const processedDates = this.processDates(dates, !!asString);
+
+      return {
+        ruleSetString,
+        ruleSet,
+        occurrences: processedDates as any,
+      };
+    } catch (error: any) {
+      throw new BadRequestException(
+        error?.message || 'Invalid recurrence rule set string.',
+      );
+    }
+  }
+
+  private processDates(
+    dates: DateTime[],
+    asString: boolean,
+  ): DateTime[] | string[] {
+    return asString ? dates.map((dt) => dt.toString()) : dates;
+  }
+}

--- a/src/recurrence/recurrence.service.ts
+++ b/src/recurrence/recurrence.service.ts
@@ -59,7 +59,7 @@ export class RecurrenceService {
       return {
         ruleSetString: ruleSet.toString(),
         ruleSet,
-        occurrences: processedDates as any,
+        occurrences: processedDates as T extends true ? string[] : DateTime[],
       };
     } catch (error: any) {
       throw new InternalServerErrorException(


### PR DESCRIPTION
This pull request includes significant updates to the `RecurrenceService` in the `src/recurrence` directory. The main changes involve the addition of new methods and types to enhance the functionality of the recurrence service, as well as some minor updates to the `RecurrenceModule`.

Enhancements to `RecurrenceService`:

* Added imports for `BadRequestException`, `InternalServerErrorException`, `RRule`, `RRuleSet`, `DateTime`, and type definitions from the `rrule-rust` library.
* Introduced a new type `StrictRRuleSetLike` and interface `IRuleFeatOccurrences` to define the structure of recurrence rule sets and their occurrences.
* Implemented the `createDateTime` method to create `DateTime` objects.
* Added the `getOccurrences` method to generate occurrences based on provided options, including handling errors and processing dates.
* Added private methods `buildRuleSet`, `occurrencesFromString`, and `processDates` to support the main functionality of `getOccurrences`.

Minor updates to `RecurrenceModule`:

* Added a comma after `RecurrenceService` in the `providers` array.