### PR TITLE
00 event

### DIFF
--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -32,7 +32,7 @@ export class CategoriesService {
         includeRelations[typedKey] = includeInput[typedKey];
       }
     });
-    
+
     return {
       ...DEFAULT_CATEGORY_TO_BE_INCLUDED,
       ...includeRelations,

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -23,15 +23,19 @@ export class CategoriesService {
   private buildIncludeObject(
     includeInput?: CategoryIncludeInput,
   ): Prisma.CategoryInclude {
+    if (!includeInput) return DEFAULT_CATEGORY_TO_BE_INCLUDED;
+
+    const includeRelations: Prisma.CategoryInclude = {};
+    Object.keys(includeInput).forEach((key) => {
+      const typedKey = key as keyof CategoryIncludeInput;
+      if (includeInput[typedKey] !== undefined) {
+        includeRelations[typedKey] = includeInput[typedKey];
+      }
+    });
+    
     return {
       ...DEFAULT_CATEGORY_TO_BE_INCLUDED,
-      ...(includeInput && {
-        parent: includeInput.parent ?? undefined,
-        children: includeInput.children ?? undefined,
-        posts: includeInput.posts ?? undefined,
-        events: includeInput.events ?? undefined,
-        _count: includeInput._count ?? undefined,
-      }),
+      ...includeRelations,
     };
   }
 

--- a/src/events/dto/event-include.input.ts
+++ b/src/events/dto/event-include.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class EventIncludeInput {
+  @Field(() => Boolean, { nullable: true })
+  categories?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  post?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  _count?: boolean;
+}

--- a/src/events/dto/event.type.ts
+++ b/src/events/dto/event.type.ts
@@ -1,0 +1,9 @@
+import { Prisma } from '@prisma/client';
+
+export const DEFAULT_EVENT_RELATIONS_TO_BE_INCLUDED = {
+  categories: true,
+  _count: true,
+} satisfies Prisma.EventInclude;
+export type EventWithDefaultRelations = Prisma.EventGetPayload<{
+  include: typeof DEFAULT_EVENT_RELATIONS_TO_BE_INCLUDED;
+}>;

--- a/src/events/dto/recurrence-options.input.ts
+++ b/src/events/dto/recurrence-options.input.ts
@@ -1,0 +1,25 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class RRuleOptions {
+  @Field(() => String, { nullable: true })
+  frequency?: string;
+
+  @Field(() => Number, { nullable: true })
+  interval?: number;
+
+  @Field(() => Number, { nullable: true })
+  count?: number;
+
+  @Field(() => Date, { nullable: true })
+  until?: Date;
+
+  @Field(() => [Date], { nullable: true })
+  byMonthDay?: Date[];
+
+  @Field(() => [Number], { nullable: true })
+  byMonth?: number[];
+
+  @Field(() => [Number], { nullable: true })
+  byDay?: number[];
+}

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -10,10 +10,33 @@ import { UpdateEventInput } from './dto/update-event.input';
 import { PrismaService } from 'nestjs-prisma';
 import { Event } from 'src/@generated';
 import { CreatePostInput } from 'src/posts/dto/create-post.input';
+import { EventIncludeInput } from './dto/event-include.input';
+import { Prisma } from '@prisma/client';
+import { DEFAULT_EVENT_RELATIONS_TO_BE_INCLUDED } from './dto/event.type';
 
 @Injectable()
 export class EventsService {
   constructor(private readonly prismaService: PrismaService) {}
+
+  private buildIncludeRelations(
+    includeInput?: EventIncludeInput,
+  ): Prisma.EventInclude {
+    if (!includeInput) return DEFAULT_EVENT_RELATIONS_TO_BE_INCLUDED;
+
+    const includeRelations: Prisma.EventInclude = {};
+
+    Object.keys(includeInput).forEach((key) => {
+      const typedKey = key as keyof EventIncludeInput;
+      if (includeInput[typedKey] !== undefined) {
+        includeRelations[typedKey] = includeInput[typedKey];
+      }
+    });
+
+    return {
+      ...DEFAULT_EVENT_RELATIONS_TO_BE_INCLUDED,
+      ...includeRelations,
+    };
+  }
 
   private readonly logger = new Logger(EventsService.name);
 


### PR DESCRIPTION
This pull request introduces several changes to enhance the handling of include relations in the `categories` and `events` services. The changes focus on improving the flexibility and default behavior of including related entities.

### Enhancements to include relations handling:

* [`src/categories/categories.service.ts`](diffhunk://#diff-8318f5d4b8deec15c8aaf0ed28124e4b8a184c54581ac9fb037979be4169af31R26-R38): Refactored the `buildIncludeObject` method to handle `CategoryIncludeInput` more flexibly by creating an `includeRelations` object and merging it with the default values.

* [`src/events/dto/event-include.input.ts`](diffhunk://#diff-05d5245b8379376cecc80b473cc7649acc6845e0d2d0ed3aea37f809e0c96ba4R1-R13): Added a new `EventIncludeInput` class to define the structure for including related entities in event queries.

* [`src/events/dto/event.type.ts`](diffhunk://#diff-3f2e2ae5a4b025646c5f14fc9817ffb709bb203ce9025d3128701a4d94519a37R1-R9): Introduced `DEFAULT_EVENT_RELATIONS_TO_BE_INCLUDED` to specify default relations to be included and created a type alias `EventWithDefaultRelations` for payloads including these defaults.

* [`src/events/dto/recurrence-options.input.ts`](diffhunk://#diff-7b3afa01f8de8b6e9204e5a1240e76a22c741f813634bffc590b14c2e97c88a1R1-R25): Added a new `RRuleOptions` class to define recurrence options for events, including fields like `frequency`, `interval`, and `until`.

* [`src/events/events.service.ts`](diffhunk://#diff-d7d0507505083fa992eb4e75cb78c12977dfb415747ed0cacac0e39f786fe85cR13-R40): Implemented the `buildIncludeRelations` method to handle `EventIncludeInput` similarly to the categories service, allowing for flexible inclusion of related entities with default values.