### PR TITLE
update recurrent input type

### DIFF
--- a/src/recurrence/types/recurrence.input.ts
+++ b/src/recurrence/types/recurrence.input.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
 import { log } from 'console';
 import { DateTime } from 'graphql-scalars/typings/mocks';
-import { Weekday } from './weekday.input';
+import { Weekday, WeekdayInput } from './weekday.input';
 
 export enum RecurrenceFrequency {
   Yearly = 'YEARLY',
@@ -63,4 +63,59 @@ export class RecurrenceInput {
       'if given, this must be IANA string recognized by Intl API. This will be used to convert the start date to the given timezone. If not given, the start date will be treated as UTC.',
   })
   tzid?: string;
+
+  @Field(() => [Int], {
+    nullable: true,
+    description:
+      'array of integers. each integer specifies an occurrence number, corresponding to the nth occurrence of the rule inside the frequency period. For example, if the recurrence is daily and the array is [1, 3, 5], it means the first, third, and fifth occurrences will be generated.',
+  })
+  bysetpos?: number[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the month of the year. For example, if the recurrence is yearly and the array is [1, 6], it means January and June will be generated.`,
+  })
+  bymonth?: number[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the day of the month. For example, if the recurrence is monthly and the array is [1, 15], it means the first and fifteenth days of each month will be generated.`,
+  })
+  bymonthday?: number[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the day of the year. For example, if the recurrence is yearly and the array is [1, 100], it means January 1st and April 10th will be generated.`,
+  })
+  byyearday?: number[];
+
+  @Field(() => [WeekdayInput], {
+    nullable: true,
+    description: `Array of weekday objects. Each may include nth value (like "2nd Monday").`,
+  })
+  byweekday?: WeekdayInput[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the week number of the month. For example, if the recurrence is monthly and the array is [1, -1], it means the first and last weeks of each month will be generated.`,
+  })
+  byweekno?: number[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the hour of the day. For example, if the recurrence is hourly and the array is [0, 12], it means midnight and noon will be generated.`,
+  })
+  byhour?: number[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the minute of the hour. For example, if the recurrence is minutely and the array is [0, 30], it means every hour at 0 and 30 minutes will be generated.`,
+  })
+  byminute?: number[];
+
+  @Field(() => [Int], {
+    nullable: true,
+    description: `array of integers. each integer specifies the second of the minute. For example, if the recurrence is secondly and the array is [0, 30], it means every minute at 0 and 30 seconds will be generated.`,
+  })
+  bysecond?: number[];
 }


### PR DESCRIPTION
This pull request includes enhancements to the `RecurrenceInput` class in the `src/recurrence/types/recurrence.input.ts` file. The changes primarily focus on adding new fields to support more detailed recurrence rules.

Enhancements to `RecurrenceInput` class:

* Added import for `WeekdayInput` from `weekday.input` to support new field.
* Added new fields to `RecurrenceInput` class to support various recurrence rules, including `bysetpos`, `bymonth`, `bymonthday`, `byyearday`, `byweekday`, `byweekno`, `byhour`, `byminute`, and `bysecond`. Each of these fields is an array of integers or `WeekdayInput` objects, with detailed descriptions for their usage.